### PR TITLE
Fixed class names of default context attributes are not inherited to variants

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -142,7 +142,10 @@ class Attributes {
  * @return string
  */
 Attributes.prototype.toString = function () {
-    let string = ' class="' + _.join(_.uniq(this.classes), ' ') + '"';
+    let string = '';
+    if (this.classes.length) {
+        string += ' class="' + _.join(_.uniq(this.classes), ' ') + '"';
+    }
     _.forEach(this.storage, function (value, name) {
         string += ` ${name}="${value}"`;
     });

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -147,7 +147,12 @@ Attributes.prototype.toString = function () {
         string += ' class="' + _.join(_.uniq(this.classes), ' ') + '"';
     }
     _.forEach(this.storage, function (value, name) {
-        string += ` ${name}="${value}"`;
+        if (value !== null) {
+            string += ` ${name}="${value}"`;
+        }
+        else {
+            string += ` ${name}`;
+        }
     });
     return string;
 };

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -66,6 +66,19 @@ class Attributes {
     };
 
     /**
+     * Returns whether the class attribute contains a given CSS class name.
+     *
+     * @param string $classname
+     *   The CSS class name to check for.
+     *
+     * @return bool
+     *   TRUE if the class name exists, FALSE otherwise.
+     */
+    hasClass(classname) {
+        return this.classes.indexOf(classname) > -1;
+    };
+
+    /**
      * Sets an attribute to a given value.
      *
      * @param string name

--- a/src/tags/index.js
+++ b/src/tags/index.js
@@ -76,6 +76,19 @@ module.exports = function(fractal){
                             throw new Error(`Unable to render '${handle}' - component not found.`);
                         }
                         innerContext = entity.isComponent ? entity.variants().default().context : entity.context;
+
+                        // The classes of the default context attributes need to be
+                        // merged manually.
+                        // @see Twig.Template.prototype.render(), adapter.js
+                        if (!entity.isDefault) {
+                            let defaultContext = entity.parent.variants().default().context;
+                            if (defaultContext.attributes !== undefined && defaultContext.attributes.class !== undefined) {
+                                if (typeof defaultContext.attributes.class === 'string') {
+                                    defaultContext.attributes.class = defaultContext.attributes.class.split(' ');
+                                }
+                                innerContext.attributes.class = _.concat(defaultContext.attributes.class, innerContext.attributes.class);
+                            }
+                        }
                     }
 
                     _.forEach(innerContext, function (value, name) {


### PR DESCRIPTION
Problem

* Variants such as button--primary only output the class `"button--primary"`, the default class `"button"` does not appear.

* Potentially same cause: When not passing custom attributes to a component, the default component attributes are not an `Attributes` object.

* HTML element properties such as `"disabled"` can be specified with a value `"null"` to indicate that the property shall be output without an attribute value. `disabled="null"` appears literally currently.

* An empty `Attributes` object outputs an empty `class=""` attribute.
