### PR TITLE
Added support for the Drupal filter 'without'.

### DIFF
--- a/src/filters/index.js
+++ b/src/filters/index.js
@@ -9,13 +9,13 @@ module.exports = function (fractal) {
             return str;
         },
         without(element, exclude_elements) {
-            filtred_element = element;
+            filtered_element = element;
             exclude_elements.forEach(function (exclude) {
                 if (element.hasOwnProperty(exclude)) {
-                    delete filtred_element[exclude];
+                    delete filtered_element[exclude];
                 }
             });
-            return filtred_element;
+            return filtered_element;
         },
         path: require('./path.js')(fractal),
     }

--- a/src/filters/index.js
+++ b/src/filters/index.js
@@ -1,4 +1,5 @@
 'use strict';
+const _ = require('lodash');
 
 module.exports = function (fractal) {
     return {
@@ -9,7 +10,7 @@ module.exports = function (fractal) {
             return str;
         },
         without(element, exclude_elements) {
-            filtered_element = element;
+            var filtered_element = _.cloneDeep(element);
             exclude_elements.forEach(function (exclude) {
                 if (element.hasOwnProperty(exclude)) {
                     delete filtered_element[exclude];

--- a/src/filters/index.js
+++ b/src/filters/index.js
@@ -8,13 +8,14 @@ module.exports = function (fractal) {
         field_value(str) {
             return str;
         },
-        without(element, exclude) {
-            for (var i = 0; i < exclude.length; i++) {
-                if (element.hasOwnProperty(exclude[i])) {
-                    delete element[exclude[i]];
+        without(element, exclude_elements) {
+            filtred_element = element;
+            exclude_elements.forEach(function (exclude) {
+                if (element.hasOwnProperty(exclude)) {
+                    delete filtred_element[exclude];
                 }
-            }
-            return element;
+            });
+            return filtred_element;
         },
         path: require('./path.js')(fractal),
     }

--- a/src/filters/index.js
+++ b/src/filters/index.js
@@ -8,6 +8,14 @@ module.exports = function (fractal) {
         field_value(str) {
             return str;
         },
+        without(element, exclude) {
+            for (var i = 0; i < exclude.length; i++) {
+                if (element.hasOwnProperty(exclude[i])) {
+                    delete element[exclude[i]];
+                }
+            }
+            return element;
+        },
         path: require('./path.js')(fractal),
     }
 };


### PR DESCRIPTION
Drupal 8 implements the twig filter `without` to render elements without some of its children elements: https://github.com/drupal/drupal/blob/8.4.x/core/themes/engines/twig/twig.engine#L121-L152

This PR emulates the same behaviour for the fractal twig adapter