### PR TITLE
Fixed: Fractal errors are displayed as async config error hiding the real error.

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -66,7 +66,6 @@ class TwigAdapter extends Fractal.Adapter {
 
                     if (handle) {
                         try {
-
                             let prefixMatcher = new RegExp(`^\\${self._config.handlePrefix}`);
                             let entity = source.find(handle.replace(prefixMatcher, '@'));
                             if (entity) {

--- a/src/tags/index.js
+++ b/src/tags/index.js
@@ -78,7 +78,9 @@ module.exports = function(fractal){
                     else {
                         const entity = components.find(handle);
                         if (!entity) {
-                            throw new Error(`Unable to render '${handle}' - component not found.`);
+                            var not_found_error = new Error(`Unable to render '${handle}' - component not found.`);
+                            console.log(not_found_error.stack);
+                            throw not_found_error;
                         }
                         try {
                             innerContext = entity.isComponent ? entity.variants().default().context : entity.context;


### PR DESCRIPTION
Corrections on render tag implementation and adapter:
- Added better error handling with try - catch statements
- Added async aware code: using async API, passing `allow_async = true` in API calls, and using Promises when need.

References:
- `allow_sync` on twigjs, are declared as third parameter like in https://github.com/twigjs/twig.js/blob/master/src/twig.core.js#L755 (is just an example, is similar to all calls.)

- https://github.com/twigjs/twig.js/blob/master/src/twig.logic.js#L718-L804