### PR TITLE
Fixed 'Cannot read property 'length' of undefined' error.

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -143,7 +143,7 @@ class Attributes {
  */
 Attributes.prototype.toString = function () {
     let string = '';
-    if (this.classes.length) {
+    if (this.classes && this.classes.length) {
         string += ' class="' + _.join(_.uniq(this.classes), ' ') + '"';
     }
     _.forEach(this.storage, function (value, name) {


### PR DESCRIPTION
Using filters to various elements throw an error because the code is assuming that `classes` key exists.