### PR TITLE
Added helper class to expose YAML config in JS.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netzstrategen/twig-drupal-fractal-adapter",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Twig template adapter for Fractal.",
   "main": "index.js",
   "repository": {

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const fs = require('fs');
+const glob = require('glob');
+const yaml = require('js-yaml');
+
+const fractal = require('../../../../fractal.config');
+
+
+class ComponentConfig {
+
+  constructor(componentName) {
+    this.componentName = componentName;
+    this.componentsPath = fractal.components.get('path');
+  }
+
+  getFilePath() {
+    return glob.sync(this.componentsPath + '/**/**/' + this.componentName + '.config.yml').toString();
+  }
+
+  getConfig() {
+    try {
+      let contents = fs.readFileSync(this.getFilePath(), 'utf8');
+      return yaml.load(contents);
+      // console.log(util.inspect(data, false, 10, true));
+    }
+    catch (err) {
+      console.log(err.stack || String(err));
+    }
+  }
+}
+
+module.exports = ComponentConfig;

--- a/src/config.js
+++ b/src/config.js
@@ -11,6 +11,11 @@ const fractal = require('../../../../fractal.config');
  *
  * Fractal YAML contains 'real' configuration shared between pattern library and application.
  * Use `*.config.js` to populate Fractal components with dummy data which isn't exposed to app.
+ *
+ * @usage:
+    const ComponentConfig = require('@netzstrategen/twig-drupal-fractal-adapter/src/config');
+    const componentHandle = require('path').basename(__filename).split('.')[0]; // Pass component name to class.
+    let config = new ComponentConfig(componentHandle).getConfig(); // Assign contents of *.config.yml to variable.
  */
 class ComponentConfig {
 
@@ -27,7 +32,6 @@ class ComponentConfig {
     try {
       let contents = fs.readFileSync(this.getFilePath(), 'utf8');
       return yaml.load(contents);
-      // console.log(util.inspect(data, false, 10, true));
     }
     catch (err) {
       console.log(err.stack || String(err));

--- a/src/config.js
+++ b/src/config.js
@@ -6,7 +6,12 @@ const yaml = require('js-yaml');
 
 const fractal = require('../../../../fractal.config');
 
-
+/**
+ * Export contents of sibling `*.config.yml` component config file.
+ *
+ * Fractal YAML contains 'real' configuration shared between pattern library and application.
+ * Use `*.config.js` to populate Fractal components with dummy data which isn't exposed to app.
+ */
 class ComponentConfig {
 
   constructor(componentName) {


### PR DESCRIPTION
- With Drupal/CUE we use Fractal YAML files as configuration.
- However, we don't want any dummy data to be exposed to the app front-end.
- Use JS config to populate Fractal and consume YAML config for 'real' configuration such as CSS classes.