### PR TITLE
Changed config helper to use dynamic component references.

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,10 +1,8 @@
 'use strict';
 
 const fs = require('fs');
-const glob = require('glob');
+const path = require('path');
 const yaml = require('js-yaml');
-
-const fractal = require('../../../../fractal.config');
 
 /**
  * Export contents of sibling `*.config.yml` component config file.
@@ -14,20 +12,24 @@ const fractal = require('../../../../fractal.config');
  *
  * @usage:
     const ComponentConfig = require('@netzstrategen/twig-drupal-fractal-adapter/src/config');
-    const componentHandle = require('path').basename(__filename).split('.')[0]; // Pass component name to class.
-    let config = new ComponentConfig(componentHandle).getConfig(); // Assign contents of *.config.yml to variable.
+    let config = new ComponentConfig().getConfig(); // Assign contents of *.config.yml to variable.
  */
 class ComponentConfig {
 
-  constructor(componentName) {
-    this.componentName = componentName;
-    this.componentsPath = fractal.components.get('path');
-  }
-
+  /**
+   * Returns the yml config file path by using the parent filename of
+   * the global module object.
+   *
+   * @see https://nodejs.org/api/modules.html#modules_the_module_object
+   */
   getFilePath() {
-    return glob.sync(this.componentsPath + '/**/**/' + this.componentName + '.config.yml').toString();
+    let pathinfo = path.parse(module.parent.filename);
+    return pathinfo.dir + '/' + pathinfo.name + '.yml';
   }
 
+  /**
+   * Returns the parsed yml config.
+   */
   getConfig() {
     try {
       let contents = fs.readFileSync(this.getFilePath(), 'utf8');


### PR DESCRIPTION
As a follow-up of #9, the code was refactored to not rely on the fractal config directly but rather use the path of the parent file by using the global module object.

In addition the glob has been dropped as the configs will placed next to each other which will also be more performant on a growing file structure.