### PR TITLE
Added use component default value if parent context key is not set.

### DIFF
--- a/src/tags/index.js
+++ b/src/tags/index.js
@@ -105,8 +105,10 @@ module.exports = function(fractal){
                             if (name.indexOf('attributes') > -1) {
                                 innerContext[name].merge(value);
                             }
-                            else {
-                                innerContext[name] = value;
+                            // If the parent context key is missing (undefined) or true,
+                            // render the component default value, use passed value otherwise.
+                            else if (typeof value !== 'undefined' && value !== true) {
+                              innerContext[name] = value;
                             }
                         });
                     }

--- a/src/tags/index.js
+++ b/src/tags/index.js
@@ -95,21 +95,17 @@ module.exports = function(fractal){
 
                     if (token.withStack !== undefined) {
                         passedArguments = Twig.expression.parse.apply(this, [token.withStack, context]);
-
-                        _.forEach(passedArguments, function (value, name) {
-                            // It makes no sense to pass variables that are not
-                            // supported by the component.
-                            if (innerContext[name] === undefined) {
-                                return;
-                            }
-                            if (name.indexOf('attributes') > -1) {
-                                innerContext[name].merge(value);
-                            }
-                            // If the parent context key is missing (undefined) or true,
-                            // render the component default value, use passed value otherwise.
-                            else if (typeof value !== 'undefined') {
-                              innerContext[name] = value;
-                            }
+                        _.forEach(innerContext, function (value, name) {
+                          // Override default value only if an argument value is passed.
+                          if (!passedArguments.hasOwnProperty(name) || typeof passedArguments[name] === 'undefined') {
+                            return;
+                          }
+                          if (name.indexOf('attributes') > -1) {
+                            value.merge(passedArguments[name]);
+                          }
+                          else {
+                            innerContext[name] = passedArguments[name];
+                          }
                         });
                     }
 

--- a/src/tags/index.js
+++ b/src/tags/index.js
@@ -107,7 +107,7 @@ module.exports = function(fractal){
                             }
                             // If the parent context key is missing (undefined) or true,
                             // render the component default value, use passed value otherwise.
-                            else if (typeof value !== 'undefined' && value !== true) {
+                            else if (typeof value !== 'undefined') {
                               innerContext[name] = value;
                             }
                         });

--- a/src/tags/index.js
+++ b/src/tags/index.js
@@ -99,6 +99,10 @@ module.exports = function(fractal){
                         // intentionally ignored.
                         _.forEach(innerContext, function (value, name) {
                           // Override default value only if an argument value is passed.
+                          // Ignore undefined variables, which may appear when rendering
+                          // a component with dummy/faker data but without values for its
+                          // child components, so that each component only generates its
+                          // own dummy data.
                           if (!passedArguments.hasOwnProperty(name) || typeof passedArguments[name] === 'undefined') {
                             return;
                           }

--- a/src/tags/index.js
+++ b/src/tags/index.js
@@ -95,6 +95,8 @@ module.exports = function(fractal){
 
                     if (token.withStack !== undefined) {
                         passedArguments = Twig.expression.parse.apply(this, [token.withStack, context]);
+                        // Variables not defined by the component context are
+                        // intentionally ignored.
                         _.forEach(innerContext, function (value, name) {
                           // Override default value only if an argument value is passed.
                           if (!passedArguments.hasOwnProperty(name) || typeof passedArguments[name] === 'undefined') {


### PR DESCRIPTION
### Problem
- Dummy/fake data needs to be passed trough multiple layers if nested components want to make use of it
- This results in extensive and repetitive markup

### Goal
- Prevent overriding default values if no argument value is given to avoid repetitive markup and maintain DRY components
- Have lean code components as most of the default, empty keys can be stripped from the markup

### Description
- This PR prevents overriding a component context value if no key or `true` is passed from a parent
- This will result in less code as you don't need to pass explicit values but use defaults from the components itself
- I also chose to allow `true` to use a default value to have the possibility to denote it explicitly in a parent component if desired

### Example
- If we don't pass the subhead context the subhead component will receive undefined, but will use it's default value instead.

#### component.(twig|config.js):
```js
module.exports = {
  context: {}
}
```

```twig
{{ dump(subhead) }}
{# -> undefined #}
{% render 'subhead.twig' with {
  text: subhead
} %}
```
#### subhead.(twig|config.js):
```js
module.exports = {
  context: {
    text: 'Hello world'
  }
}
```
```twig
{{ dump }}
{# -> Hello world #}
```