### PR TITLE
Fixed Attributes.merge() breaks when passing null.

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -103,6 +103,9 @@ class Attributes {
      * @return self
      */
     merge(attributes) {
+        if (typeof attributes !== 'object') {
+            return this;
+        }
         let self = this;
         if (attributes.constructor.name === 'Attributes') {
             this.classes = _.concat(this.classes, attributes.classes);


### PR DESCRIPTION
Sometimes it is necessary to dynamically enhance an existing Attributes object with a dynamic variable – that might not be set – like this:
```twig
{% render '@atoms/link/link.twig' with {
  text: link.text,
  attributes: link_attributes.merge(link.attributes ? link.attributes).setAttribute('href', link.url)
} %}
```
In that case, the current merge() method blows up, because null/undefined does not have a property "constructor".