### PR TITLE
Fixed attribute function cannot access properties.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netzstrategen/fractal-twig",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Twig template adapter for Fractal.",
   "main": "index.js",
   "repository": {

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -187,23 +187,25 @@ class Attributes {
         return new Proxy(attributes, {
             get (target, name, receiver) {
                 if (typeof name === 'string' && !Reflect.has(target, name)) {
-                    if (name.indexOf('get') !== -1) {
-                        // Undo Twig's property name to method name conversion.
-                        name = name.replace('get', '').toLowerCase();
-                        // Re-route into storage unless class property is requested.
-                        if (name === 'class') {
-                            name = 'classes';
-                        }
-                        else {
-                            target = target.storage;
-                        }
+                    // Undo Twig's property name to method name conversion.
+                    name = name.replace('get', '').toLowerCase();
+                    // Re-route into storage unless class property is requested.
+                    if (name === 'class') {
+                        name = 'classes';
                     }
-                    // Do not forward other property accesses and tests (like isset()).
                     else {
-                        return undefined;
+                        target = target.storage;
                     }
                 }
                 return Reflect.get(target, name, receiver);
+            },
+            getOwnPropertyDescriptor(target, name) {
+                return {
+                    configurable: true,
+                    enumerable: true,
+                    writable: true,
+                    value: this.get(target, name),
+                };
             }
         });
     }

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -188,7 +188,7 @@ class Attributes {
             get (target, name, receiver) {
                 if (typeof name === 'string' && !Reflect.has(target, name)) {
                     // Undo Twig's property name to method name conversion.
-                    name = name.replace('get', '').toLowerCase();
+                    name = name.replace(/^get/, '').toLowerCase();
                     // Re-route into storage unless class property is requested.
                     if (name === 'class') {
                         name = 'classes';


### PR DESCRIPTION
### Description
- Using the twig `attribute` function allows to get keys with special characters as e.g. `-`
- This PR implements a trap for the `getOwnPropertyDescriptor` so `hasOwnProperty` and `getOwnProperty` return the correct values
- As the trap uses the direct property name, the explicit check for `get` was removed to handle both cases