### PR TITLE
Added feature to provide variant dummy data.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "@netzstrategen/twig-drupal-fractal-adapter",
+  "version": "2.2.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "deepmerge": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.0.0.tgz",
+      "integrity": "sha512-YZ1rOP5+kHor4hMAH+HRQnBQHg+wvS1un1hAOuIcxcBy0hzcUf6Jg2a1w65kpoOUnurOfZbERwjI1TfZxNjcww=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netzstrategen/fractal-twig",
-  "version": "2.2.4",
+  "version": "2.3.0",
   "description": "Twig template adapter for Fractal.",
   "main": "index.js",
   "repository": {
@@ -16,6 +16,7 @@
   "dependencies": {
     "@frctl/fractal": "latest",
     "callsites": "^3.1.0",
+    "deepmerge": "^4.0.0",
     "glob": "^7.1.2",
     "js-yaml": "^3.9.0",
     "lodash": "^4.15.0",

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const callsites = require('callsites');
+const deepmerge = require('deepmerge');
 const fs = require('fs');
 const yaml = require('js-yaml');
 
@@ -39,6 +40,32 @@ class ComponentConfig {
       console.log(err.stack || String(err));
     }
   }
+
+  /**
+   * Merges the source element by the variant name into the destination array.
+   */
+  merge(destination = {}, source = {}, options) {
+    const defaults = {
+      customMerge: (key) => {
+        if (key !== 'variants') {
+          return;
+        }
+        return (destination, source) => {
+          source.forEach(sourceVariant => {
+            destination.forEach((destinationVariant, index) => {
+              if (destinationVariant.name === sourceVariant.name) {
+                destination[index] = deepmerge(destination[index], sourceVariant);
+              }
+            });
+          });
+          return destination;
+        }
+      },
+    };
+    options = options || defaults;
+    return deepmerge(destination, source, options)
+  }
+
 }
 
 module.exports = ComponentConfig;


### PR DESCRIPTION
This PR adds the possibility to provide dummy data for component variants. The variants are getting merged by the `name` property.

```js
const ComponentConfig = new (require('@netzstrategen/twig-drupal-fractal-adapter/src/config'))();
const config = ComponentConfig.getConfig();

let custom = {
  variants: [{
    name: 'youtube',
    context: config.generateDummyContext('youtube'),
  }],
};
module.exports = ComponentConfig.merge(config, custom);
```