### PR TITLE
Added Github action to publish the NPM package.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,22 @@
+name: NPM Publish
+
+on: push
+jobs:
+  shellLint:
+    name: Shell Lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Shell Lint
+      uses: actions/bin/shellcheck@master
+      with:
+        args: entrypoint.sh
+    - name: Publish Filter
+      uses: actions/bin/filter@master
+      with:
+        args: branch master
+    - name: Publish
+      uses: mikeal/merge-release@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,20 +1,14 @@
 name: NPM Publish
-
 on:
   push:
     branches:
       - master
-      - action-npm-publish-fab
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [12.x]
-
-
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - action-npm-publish-fab
 jobs:
   build:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,20 +1,28 @@
 name: NPM Publish
 
-on: push
+on:
+  push:
+    branches:
+      - master
 jobs:
-  shellLint:
-    name: Shell Lint
+  build:
+
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+
     steps:
-    - uses: actions/checkout@master
-    - name: Shell Lint
-      uses: actions/bin/shellcheck@master
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
       with:
-        args: entrypoint.sh
-    - name: Publish Filter
-      uses: actions/bin/filter@master
-      with:
-        args: branch master
+        node-version: ${{ matrix.node-version }}
+    - name: npm install
+      run: |
+        npm install
     - name: Publish
       uses: mikeal/merge-release@master
       env:


### PR DESCRIPTION
### Description
- This PR adds a Github Action to automatically publish a new NPM and Github version
- It's running this script https://github.com/mikeal/merge-release/blob/master/merge-release-run.js
- The version number is increased as follows: 
    > Based on the commit messages, increment the version from the lastest release.
    If the string "BREAKING CHANGE" is found anywhere in any of the commit 
messages or descriptions the major version will be incremented.
    If a commit message begins with the string "feat" then the minor version will be increased. This works for most common commit metadata for feature additions: 
    "feat: new API" and "feature: new API".
    All other changes will increment the patch version.
- We can copy this script and adjust it to our needs


### Todo
- Raise version in `package.json` too