### PR TITLE
Updated twig to 1.14.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netzstrategen/fractal-twig",
-  "version": "2.2.4",
+  "version": "2.3.0",
   "description": "Twig template adapter for Fractal.",
   "main": "index.js",
   "repository": {
@@ -20,6 +20,6 @@
     "js-yaml": "^3.9.0",
     "lodash": "^4.15.0",
     "query-string": "^4.3.2",
-    "twig": "^1.10.5"
+    "twig": "^1.14.0"
   }
 }

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -61,7 +61,7 @@ class TwigAdapter extends Fractal.Adapter {
              */
 
             const render = Twig.Template.prototype.render;
-            Twig.Template.prototype.render = function(context, params) {
+            Twig.Template.prototype.render = function(context, params, allowAsync) {
 
                 if (!self._config.pristine && this.id) {
 
@@ -131,7 +131,7 @@ class TwigAdapter extends Fractal.Adapter {
                     });
                 }
 
-                return render.call(this, context, params);
+                return render.call(this, context, params, allowAsync);
             };
 
             /*

--- a/src/tags/index.js
+++ b/src/tags/index.js
@@ -142,7 +142,7 @@ module.exports = function(fractal){
                 },
                 parse: function (token, context, chain) {
                     var that = this;
-                    return Twig.parseAsync.call(that, token.output, context)
+                    return Twig.expression.parseAsync.call(that, token.output, context)
                     .then(function (value) {
                         var plural_token = false;
                         var plural_position = 0;
@@ -174,7 +174,7 @@ module.exports = function(fractal){
 
                         return {
                             chain: chain,
-                            output: Twig.parse.apply(that, [token.output, context])
+                            output: Twig.expression.parse.apply(that, [token.output, context])
                         };
                     });
                 }

--- a/src/tags/index.js
+++ b/src/tags/index.js
@@ -53,6 +53,7 @@ module.exports = function(fractal){
                 },
 
                 parse: function (token, context, chain) {
+                    let state = this;
                     let components = fractal.components;
 
                     let file = Twig.expression.parse.apply(this, [token.stack, context]);
@@ -119,7 +120,7 @@ module.exports = function(fractal){
                         template = file;
                     }
                     else {
-                        template = this.importFile(file);
+                        template = state.template.importFile(file);
                     }
 
                     return {


### PR DESCRIPTION
This PR fixes the following errors:
```
Error: TypeError: this.importFile is not a function
    at /Users/sun/sites/nest/bnn/front/templates/node_modules/@netzstrategen/fractal-twig/src/adapter.js:286:24
    at new Promise ()
    at TwigAdapter.render (/Users/sun/sites/nest/bnn/front/templates/node_modules/@netzstrategen/fractal-twig/src/adapter.js:272:16)
    at ComponentSource._renderVariant (/Users/sun/sites/nest/bnn/front/templates/node_modules/@frctl/fractal/src/api/components/source.js:207:30)
    at _renderVariant.next ()
```
Upstream: https://github.com/twigjs/twig.js/blob/524e6cf974618d1a0ea8d832015ca9f8958a3564/src/twig.logic.js#L817

```
Error: TypeError: Cannot read property 'call' of undefined
    at /Users/sun/sites/nest/bnn/front/templates/node_modules/@netzstrategen/fractal-twig/src/adapter.js:286:24
    at new Promise ()
    at TwigAdapter.render (/Users/sun/sites/nest/bnn/front/templates/node_modules/@netzstrategen/fractal-twig/src/adapter.js:272:16)
    at ComponentSource._wrapInLayout (/Users/sun/sites/nest/bnn/front/templates/node_modules/@frctl/fractal/src/api/components/source.js:269:43)
    at _wrapInLayout.next ()
    at onFulfilled (/Users/sun/sites/nest/bnn/front/templates/node_modules/co/index.js:65:19)
```
Upstream: Twig.expression.parseAsync.call(): https://github.com/twigjs/twig.js/blob/326c59e5d6069ac901aa441b00faebc849b689d1/src/twig.core.js#L990